### PR TITLE
Add city_setup tool + expand tenant_bootstrap with workflow copy

### DIFF
--- a/src/tools/validators.ts
+++ b/src/tools/validators.ts
@@ -8,7 +8,7 @@ import { digitApi } from '../services/digit-api.js';
  * Input is an unordered array of { boundaryType, parentBoundaryType }.
  * Returns types ordered root-first (e.g. ["Country", "State", "District", ...]).
  */
-function buildOrderedLevels(
+export function buildOrderedLevels(
   hierarchy: { boundaryType: string; parentBoundaryType?: string | null }[]
 ): string[] {
   const childMap = new Map<string, string>();


### PR DESCRIPTION
## Summary
- Adds `city_setup` composite tool: single call to create a city-level tenant with tenant record, dual-scoped ADMIN user, workflow definitions, and boundary hierarchy
- Expands `tenant_bootstrap` with Step 5 (workflow copy) and `nextSteps` guidance in output
- Extracts shared `copyWorkflowDefinitions` helper used by both tools
- Simplifies e2e test: replaces 3 manual setup steps with 1 `city_setup` call (21 → 19 tests)

Closes #9

## Test plan
- [x] `npm run build` — compiles cleanly
- [x] `npm run test:ci` — 127 integration tests pass (59/59 tools, 100% coverage)
- [x] `npm run test:e2e` — 19/19 e2e tests pass, full PGR lifecycle via `city_setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated city setup tool for streamlined tenant provisioning, including idempotent workflow definition copying and outcome metrics
  * Tenant bootstrap now surfaces workflow copy results and supports optional boundary hierarchy and entity provisioning

* **Documentation**
  * New comprehensive UI guide for building a PGR UI against DIGIT APIs
  * Docs search/get enhanced to support local documentation alongside remote results

* **Tests**
  * End-to-end tests updated to use the new city setup flow, simplifying provisioning steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->