### PR TITLE
fix: enrich HRMS employee data with tenantId and role name (#404)

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -382,7 +382,23 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         return { data: normalizeMdmsRecord(record, config) };
       }
       if (config.type === 'hrms') {
-        const [employee] = await client.employeeCreate(tenantId, [params.data as Record<string, unknown>]);
+        const empData = { ...params.data as Record<string, unknown> };
+        // Enrich jurisdiction boundary with tenantId if empty
+        const jurisdictions = empData.jurisdictions as Array<Record<string, unknown>> | undefined;
+        if (jurisdictions?.[0] && !jurisdictions[0].boundary) {
+          jurisdictions[0].boundary = tenantId;
+        }
+        // Ensure role name is present (HRMS requires it)
+        const user = empData.user as Record<string, unknown> | undefined;
+        const roles = user?.roles as Array<Record<string, unknown>> | undefined;
+        if (roles) {
+          for (const role of roles) {
+            if (role.code && !role.name) {
+              role.name = String(role.code).charAt(0) + String(role.code).slice(1).toLowerCase();
+            }
+          }
+        }
+        const [employee] = await client.employeeCreate(tenantId, [empData]);
         return { data: normalizeRecord(employee, config) };
       }
       if (config.type === 'pgr') {


### PR DESCRIPTION
## Summary

- **Root cause**: HRMS `_create` API requires `roles[0].name` (NotNull constraint) and a valid `jurisdictions[0].boundary` (must match tenantId). The data provider was passing through form data without enriching these fields, causing 400 errors.
- **Fix**: The data provider now enriches employee create payloads before calling HRMS:
  - Auto-fills empty `jurisdictions[0].boundary` with the current `tenantId`
  - Auto-fills missing `role.name` from `role.code` (capitalizes first letter, lowercases rest)

## Changes

| File | Change |
|------|--------|
| `dataProvider.ts` | Add HRMS employee data enrichment before `employeeCreate` call |

## Related

- Companion PR: ChakshuGautam/Citizen-Complaint-Resolution-System#11 (UI form fix)

## Test plan

- [ ] Create an employee via Configurator UI with only role code set (no name) — should succeed
- [ ] Create an employee with empty jurisdiction boundary — should auto-fill with tenantId
- [ ] Verify existing employee creation flows still work (no regression)
- [ ] Run DIGIT-MCP integration tests: `npx tsx test-integration-full.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HRMS record creation to automatically populate missing default values for improved data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->