### PR TITLE
feat(tenant_bootstrap): synth UserValidation mobile rule + bridge ACCESSCONTROL-ACTIONS

### DIFF
--- a/src/tools/mdms-tenant.ts
+++ b/src/tools/mdms-tenant.ts
@@ -14,6 +14,36 @@ import type { ProbeReport } from '../utils/probe.js';
 import { loadFromXlsx } from '../utils/xlsx-loader.js';
 
 /**
+ * Derive a mobile number that satisfies the TARGET tenant's mobile rule.
+ *
+ * tenant_bootstrap copies an ADMIN from the source country, but that mobile
+ * won't match a different target country's UserValidation pattern (e.g. India
+ * `^[6-9][0-9]{9}$` vs Mozambique `^8[0-9]{8}$`). egov-user's _createnovalidate
+ * enforces the pattern, so the copied/fallback `9999999999` is rejected and the
+ * ADMIN row never gets created — login then fails. This generates a conforming
+ * placeholder from the same `mobile_regex` the bootstrap already receives.
+ *
+ * Returns `preferred` if it already matches; else the first-valid-lead-digit +
+ * a repeated tail padded to `length` that the regex accepts; else best-effort.
+ */
+export function deriveValidMobile(regex: string, length: number, preferred?: string): string {
+  let re: RegExp | null = null;
+  try { re = new RegExp(regex); } catch { re = null; }
+  const matches = (s?: string): s is string => !!s && (!re || re.test(s));
+  if (matches(preferred)) return preferred;
+  const n = length && length > 0 ? length : 10;
+  // Lead digit: a literal (`^8`) or the first member of a class (`^[6-9]`).
+  const body = (regex || '').replace(/^\^/, '');
+  const lead = body.match(/^\[([0-9])/) || body.match(/^([0-9])/);
+  const first = lead ? lead[1] : '9';
+  for (const d of ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']) {
+    const cand = first + d.repeat(Math.max(0, n - 1));
+    if (cand.length === n && matches(cand)) return cand;
+  }
+  return preferred || '9'.repeat(n);
+}
+
+/**
  * Search for MDMS records across all state tenants.
  * First queries the default state tenant to discover all root-level tenants,
  * then queries each discovered root to get the complete set.
@@ -877,6 +907,14 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           type: 'string',
           description: 'Error message (or localization key) for the back-compat "mobile" rule.',
         },
+        admin_mobile: {
+          type: 'string',
+          description:
+            'Mobile number for the provisioned ADMIN user on the target tenant. Optional — ' +
+            'if omitted, a value conforming to mobile_regex is generated (the source country\'s ' +
+            'mobile would fail the target tenant\'s UserValidation, e.g. India 10-digit vs ' +
+            'Mozambique ^8[0-9]{8}$). Set it to pin a specific number.',
+        },
         user_validation: {
           type: 'array',
           description:
@@ -1356,7 +1394,14 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         const sourceUser = existingUsers[0];
         const userName = (sourceUser?.userName as string) || currentUsername;
         const name = (sourceUser?.name as string) || 'Admin';
-        const mobileNumber = (sourceUser?.mobileNumber as string) || '9999999999';
+        // Must satisfy the TARGET tenant's mobile rule, not the source country's.
+        // Prefer an explicit admin_mobile, else the source mobile if it happens
+        // to validate, else generate a conforming one from mobile_regex.
+        const mobileNumber = deriveValidMobile(
+          mobileRegex,
+          Number(args.mobile_length) || 10,
+          (args.admin_mobile as string) || (sourceUser?.mobileNumber as string),
+        );
 
         // Standard roles needed for full platform operations on the new tenant
         const standardRoles = [
@@ -1721,7 +1766,12 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
               const userPayload: Record<string, unknown> = {
                 name: (adminRecord?.name as string) || 'Administrator',
                 userName: adminUserName,
-                mobileNumber: (adminRecord?.mobileNumber as string) || '9999999999',
+                // Same target-tenant mobile rule applies to the HRMS user payload.
+                mobileNumber: deriveValidMobile(
+                  mobileRegex,
+                  Number(args.mobile_length) || 10,
+                  (args.admin_mobile as string) || (adminRecord?.mobileNumber as string),
+                ),
                 emailId: (adminRecord?.emailId as string) || null,
                 gender: (adminRecord?.gender as string) || 'MALE',
                 type: 'EMPLOYEE',

--- a/src/tools/mdms-tenant.ts
+++ b/src/tools/mdms-tenant.ts
@@ -870,8 +870,30 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         mobile_length: {
           type: 'integer',
           description:
-            'Mobile-number length (min=max) for the UserValidation "mobile" rule. ' +
-            'Default 10 (India). Kenya/Mozambique: 9.',
+            'Mobile-number length (min=max) for the back-compat "mobile" UserValidation rule. ' +
+            'Default 10 (India). Kenya/Mozambique: 9. Ignored when user_validation is supplied.',
+        },
+        mobile_error_message: {
+          type: 'string',
+          description: 'Error message (or localization key) for the back-compat "mobile" rule.',
+        },
+        user_validation: {
+          type: 'array',
+          description:
+            'Config-driven user-field validation rules — one entry per field. Fully declarative: ' +
+            'a new country/field is config, not code. Each entry maps to a common-masters.UserValidation ' +
+            'record (egov-user ValidationData). When supplied, supersedes mobile_regex/mobile_length.',
+          items: {
+            type: 'object',
+            properties: {
+              fieldType: { type: 'string', description: 'e.g. "mobile", "userName", "email", "name"' },
+              pattern: { type: 'string', description: 'regex the field value must match' },
+              minLength: { type: 'integer' },
+              maxLength: { type: 'integer' },
+              errorMessage: { type: 'string', description: 'message or localization key' },
+            },
+            required: ['fieldType', 'pattern'],
+          },
         },
       },
       required: ['target_tenant'],
@@ -1184,7 +1206,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         pct: 75,
       });
 
-      // ── Step 3b: synthesize common-masters.UserValidation ───────────────
+      // ── Step 3b: synthesize common-masters.UserValidation (config-driven) ─
       // Source tenants (pg/statea) ship NO UserValidation. Without a 'mobile'
       // field rule egov-user falls back to a hardcoded 10-digit regex and
       // rejects 8/9-digit numbers (Kenya/Mozambique) → citizen register fails
@@ -1193,13 +1215,25 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       // SHAPE (egov-user >=1.2.8 MobileNumberValidator / ValidationData model):
       //   one record per field, data = { fieldType, isActive, rules:{
       //   pattern, minLength, maxLength, errorMessage } }. The validator
-      //   filters by fieldType=='mobile' && isActive. (The old flat
-      //   {userName,mobileNumber,...} regex map is NOT read by this build.)
+      //   filters by fieldType && isActive. uid via x-unique:['fieldType'].
       //
-      // uid: x-unique:['fieldType'] → mdms-v2 derives uid from data.fieldType
-      //   value ('mobile'). (x-unique IS required by mdms-v2 schema-create;
-      //   pointing it at fieldType gives a stable, correct uid.)
-      emitProgress({ phase: 'uservalidation:start', message: 'Synthesizing UserValidation mobile rule (citizen register)', pct: 76 });
+      // FULLY CONFIG-DRIVEN: the caller passes `user_validation` — a list of
+      // { fieldType, pattern, minLength, maxLength, errorMessage } — so a new
+      // country/field is pure config, no code. `mobile_regex`/`mobile_length`
+      // are a back-compat shorthand that builds a single 'mobile' entry when
+      // `user_validation` isn't supplied.
+      const validationRules: Array<{ fieldType: string; pattern: string; minLength?: number; maxLength?: number; errorMessage?: string }> =
+        Array.isArray(args.user_validation) && (args.user_validation as unknown[]).length > 0
+          ? (args.user_validation as typeof validationRules)
+          : [{
+              fieldType: 'mobile',
+              pattern: mobileRegex,
+              minLength: Number(args.mobile_length) || 10,
+              maxLength: Number(args.mobile_length) || 10,
+              errorMessage: (args.mobile_error_message as string) ||
+                `Invalid mobile number (expected ${Number(args.mobile_length) || 10} digits matching ${mobileRegex})`,
+            }];
+      emitProgress({ phase: 'uservalidation:start', message: `Synthesizing ${validationRules.length} UserValidation rule(s)`, pct: 76 });
       try {
         try {
           await digitApi.mdmsSchemaCreate(target, 'common-masters.UserValidation',
@@ -1228,29 +1262,30 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           const m = e instanceof Error ? e.message : String(e);
           if (!/DUPLICATE|already exists|unique/i.test(m)) throw e;
         }
-        // mdms-v2 search is HIERARCHICAL — querying a city tenant returns the
-        // state root's rows too. egov-user resolves UserValidation by EXACT
-        // tenant, so filter the existence check to exact-tenant 'mobile' rows.
+        // mdms-v2 search is HIERARCHICAL — a city query returns the root's rows
+        // too. egov-user resolves UserValidation by EXACT tenant, so filter the
+        // existence check to exact-tenant rows by fieldType.
         const existingUVraw = await digitApi.mdmsV2SearchRaw(target, 'common-masters.UserValidation', { limit: 50 });
-        const haveMobile = existingUVraw.some(
+        const haveField = (ft: string) => existingUVraw.some(
           (r) => (r as { tenantId?: string }).tenantId === target
-            && ((r as { data?: { fieldType?: string } }).data?.fieldType === 'mobile'),
+            && ((r as { data?: { fieldType?: string } }).data?.fieldType === ft),
         );
-        if (!haveMobile) {
-          const mobileLen = Number(args.mobile_length) || 10;
-          await mdmsCreateWithSchemaWait(target, 'common-masters.UserValidation', 'mobile', {
-            fieldType: 'mobile',
+        for (const rule of validationRules) {
+          if (haveField(rule.fieldType)) {
+            results.data.skipped.push(`common-masters.UserValidation/${rule.fieldType}`);
+            continue;
+          }
+          await mdmsCreateWithSchemaWait(target, 'common-masters.UserValidation', rule.fieldType, {
+            fieldType: rule.fieldType,
             isActive: true,
             rules: {
-              pattern: mobileRegex,
-              minLength: mobileLen,
-              maxLength: mobileLen,
-              errorMessage: `Invalid mobile number (expected ${mobileLen} digits matching ${mobileRegex})`,
+              pattern: rule.pattern,
+              minLength: rule.minLength ?? undefined,
+              maxLength: rule.maxLength ?? undefined,
+              errorMessage: rule.errorMessage ?? `Invalid ${rule.fieldType}`,
             },
           });
-          results.data.copied.push(`common-masters.UserValidation/mobile (synthesized, pattern=${mobileRegex}, len=${mobileLen})`);
-        } else {
-          results.data.skipped.push('common-masters.UserValidation/mobile');
+          results.data.copied.push(`common-masters.UserValidation/${rule.fieldType} (synthesized, pattern=${rule.pattern})`);
         }
       } catch (e) {
         results.data.failed.push(`common-masters.UserValidation: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/tools/mdms-tenant.ts
+++ b/src/tools/mdms-tenant.ts
@@ -859,6 +859,20 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           type: 'string',
           description: 'Existing tenant root to copy from (default: "pg")',
         },
+        mobile_regex: {
+          type: 'string',
+          description:
+            'Mobile-number regex for the synthesized common-masters.UserValidation "mobile" rule ' +
+            '(citizen register). Source tenants (pg/statea) ship no UserValidation, so it must ' +
+            'be synthesized, not copied. Default "^[6-9][0-9]{9}$" (India 10-digit). ' +
+            'Kenya: "^[17][0-9]{8}$". Mozambique: "^8[0-9]{8}$".',
+        },
+        mobile_length: {
+          type: 'integer',
+          description:
+            'Mobile-number length (min=max) for the UserValidation "mobile" rule. ' +
+            'Default 10 (India). Kenya/Mozambique: 9.',
+        },
       },
       required: ['target_tenant'],
     },
@@ -870,6 +884,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
 
       const target = args.target_tenant as string;
       const source = (args.source_tenant as string) || 'pg';
+      const mobileRegex = (args.mobile_regex as string) || '^[6-9][0-9]{9}$';
 
       const results: {
         schemas: { copied: string[]; skipped: string[]; failed: string[] };
@@ -1168,6 +1183,120 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         },
         pct: 75,
       });
+
+      // ── Step 3b: synthesize common-masters.UserValidation ───────────────
+      // Source tenants (pg/statea) ship NO UserValidation. Without a 'mobile'
+      // field rule egov-user falls back to a hardcoded 10-digit regex and
+      // rejects 8/9-digit numbers (Kenya/Mozambique) → citizen register fails
+      // INVALID_MOBILE_LENGTH.
+      //
+      // SHAPE (egov-user >=1.2.8 MobileNumberValidator / ValidationData model):
+      //   one record per field, data = { fieldType, isActive, rules:{
+      //   pattern, minLength, maxLength, errorMessage } }. The validator
+      //   filters by fieldType=='mobile' && isActive. (The old flat
+      //   {userName,mobileNumber,...} regex map is NOT read by this build.)
+      //
+      // uid: x-unique:['fieldType'] → mdms-v2 derives uid from data.fieldType
+      //   value ('mobile'). (x-unique IS required by mdms-v2 schema-create;
+      //   pointing it at fieldType gives a stable, correct uid.)
+      emitProgress({ phase: 'uservalidation:start', message: 'Synthesizing UserValidation mobile rule (citizen register)', pct: 76 });
+      try {
+        try {
+          await digitApi.mdmsSchemaCreate(target, 'common-masters.UserValidation',
+            'Per-field user validation rules (egov-user ValidationData)', {
+              type: 'object',
+              title: 'UserValidation',
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              required: ['fieldType'],
+              'x-unique': ['fieldType'],
+              properties: {
+                fieldType: { type: 'string' },
+                isActive: { type: 'boolean' },
+                rules: {
+                  type: 'object',
+                  properties: {
+                    pattern: { type: 'string' },
+                    minLength: { type: 'integer' },
+                    maxLength: { type: 'integer' },
+                    errorMessage: { type: 'string' },
+                  },
+                },
+              },
+              additionalProperties: true,
+            });
+        } catch (e) {
+          const m = e instanceof Error ? e.message : String(e);
+          if (!/DUPLICATE|already exists|unique/i.test(m)) throw e;
+        }
+        // mdms-v2 search is HIERARCHICAL — querying a city tenant returns the
+        // state root's rows too. egov-user resolves UserValidation by EXACT
+        // tenant, so filter the existence check to exact-tenant 'mobile' rows.
+        const existingUVraw = await digitApi.mdmsV2SearchRaw(target, 'common-masters.UserValidation', { limit: 50 });
+        const haveMobile = existingUVraw.some(
+          (r) => (r as { tenantId?: string }).tenantId === target
+            && ((r as { data?: { fieldType?: string } }).data?.fieldType === 'mobile'),
+        );
+        if (!haveMobile) {
+          const mobileLen = Number(args.mobile_length) || 10;
+          await mdmsCreateWithSchemaWait(target, 'common-masters.UserValidation', 'mobile', {
+            fieldType: 'mobile',
+            isActive: true,
+            rules: {
+              pattern: mobileRegex,
+              minLength: mobileLen,
+              maxLength: mobileLen,
+              errorMessage: `Invalid mobile number (expected ${mobileLen} digits matching ${mobileRegex})`,
+            },
+          });
+          results.data.copied.push(`common-masters.UserValidation/mobile (synthesized, pattern=${mobileRegex}, len=${mobileLen})`);
+        } else {
+          results.data.skipped.push('common-masters.UserValidation/mobile');
+        }
+      } catch (e) {
+        results.data.failed.push(`common-masters.UserValidation: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      // ── Step 3c: bridge ACCESSCONTROL-ACTIONS.actions from -TEST ─────────
+      // egov-accesscontrol reads ACCESSCONTROL-ACTIONS.actions, but pg/statea
+      // ship only ACCESSCONTROL-ACTIONS-TEST.actions-test. Clone the schema
+      // def under the non-TEST code and copy every row PRESERVING data.id so
+      // roleactions.actionid cross-refs still resolve. Without this the
+      // employee UI renders blank (no actions → no menu).
+      emitProgress({ phase: 'actions_bridge:start', message: 'Bridging ACCESSCONTROL-ACTIONS.actions ← actions-test', pct: 78 });
+      try {
+        const haveActions = await digitApi.mdmsSchemaSearch(target, ['ACCESSCONTROL-ACTIONS.actions']).catch(() => []);
+        if (!haveActions || haveActions.length === 0) {
+          const testSchema = (await digitApi.mdmsSchemaSearch(target, ['ACCESSCONTROL-ACTIONS-TEST.actions-test']).catch(() => []))[0];
+          if (testSchema) {
+            await digitApi.mdmsSchemaCreate(target, 'ACCESSCONTROL-ACTIONS.actions',
+              (testSchema.description as string) || 'AccessControl actions (bridged from actions-test)',
+              testSchema.definition as Record<string, unknown>).catch((e: unknown) => {
+                const m = e instanceof Error ? e.message : String(e);
+                if (!/DUPLICATE|already exists|unique/i.test(m)) throw e;
+              });
+          }
+        }
+        const testRows = await digitApi.mdmsV2SearchRaw(target, 'ACCESSCONTROL-ACTIONS-TEST.actions-test', { limit: 500 });
+        const haveRows = await digitApi.mdmsV2SearchRaw(target, 'ACCESSCONTROL-ACTIONS.actions', { limit: 500 });
+        const haveUid = new Set(haveRows.map((r) => r.uniqueIdentifier));
+        let bridged = 0;
+        for (const r of testRows) {
+          if (haveUid.has(r.uniqueIdentifier)) continue;
+          try {
+            await mdmsCreateWithSchemaWait(target, 'ACCESSCONTROL-ACTIONS.actions',
+              r.uniqueIdentifier as string, r.data as Record<string, unknown>);
+            bridged++;
+          } catch (e) {
+            const m = e instanceof Error ? e.message : String(e);
+            if (!/DUPLICATE|already exists|unique/i.test(m)) {
+              results.data.failed.push(`ACCESSCONTROL-ACTIONS.actions/${r.uniqueIdentifier}: ${m}`);
+            }
+          }
+        }
+        if (bridged > 0) results.data.copied.push(`ACCESSCONTROL-ACTIONS.actions (bridged ${bridged} rows from -TEST)`);
+      } catch (e) {
+        results.data.failed.push(`ACCESSCONTROL-ACTIONS.actions bridge: ${e instanceof Error ? e.message : String(e)}`);
+      }
 
       emitProgress({ phase: 'admin:start', message: 'Provisioning ADMIN user on the new tenant', pct: 80 });
 

--- a/src/tools/pgr-workflow.ts
+++ b/src/tools/pgr-workflow.ts
@@ -170,7 +170,7 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
         },
         citizen_mobile: {
           type: 'string',
-          description: 'Mobile number of the citizen (required, 10 digits)',
+          description: 'Mobile number of the citizen (required; tenant UserValidation enforces the pattern)',
         },
         dry_run: {
           type: 'boolean',

--- a/src/tools/validators.ts
+++ b/src/tools/validators.ts
@@ -806,7 +806,57 @@ export function registerValidatorTools(registry: ToolRegistry): void {
         }
       }
 
-      // Step 3: Create relationships top-down (ordered by hierarchy level)
+      // Step 2.5: ENTITY GATE — wait until every entity write is visible before
+      // creating relationships. boundary-service entity _create returns 200
+      // before the row is consistently readable; relationship _create validates
+      // entity existence against the store, so without this barrier a subset of
+      // relationship calls outrun their entity and fail BOUNDARY_ENTITY_DOES_NOT_EXIST
+      // (and their Quarteirão/leaf children cascade). Poll boundary search until
+      // all expected codes are present, then proceed.
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      // /boundary/_search caps results (~300), so verify the exact codes via the
+      // `codes` filter in chunks rather than counting one big search.
+      const expectedCodeList = boundaries.map((b) => b.code);
+      const expectedCount = new Set(expectedCodeList).size;
+      const GATE_TIMEOUT_MS = 180000;
+      const GATE_INTERVAL_MS = 2000;
+      const CODES_CHUNK = 200;
+      const countVisibleEntities = async (): Promise<number> => {
+        const seen = new Set<string>();
+        for (let i = 0; i < expectedCodeList.length; i += CODES_CHUNK) {
+          const chunk = expectedCodeList.slice(i, i + CODES_CHUNK);
+          // explicit limit: /boundary/_search defaults to 50 results even when
+          // codes are supplied, so without this the gate undercounts and stalls.
+          const res = await digitApi
+            .boundarySearch(tenantId, undefined, { codes: chunk, limit: chunk.length })
+            .catch(() => [] as Record<string, unknown>[]);
+          const present = new Set((res as Record<string, unknown>[]).map((e) => e.code as string));
+          for (const c of chunk) if (present.has(c)) seen.add(c);
+        }
+        return seen.size;
+      };
+      const gateStart = Date.now();
+      let entitiesVisible = 0;
+      while (Date.now() - gateStart < GATE_TIMEOUT_MS) {
+        entitiesVisible = await countVisibleEntities();
+        if (entitiesVisible >= expectedCount) break;
+        await sleep(GATE_INTERVAL_MS);
+      }
+      const entityGate = {
+        expected: expectedCount,
+        visible: entitiesVisible,
+        complete: entitiesVisible >= expectedCount,
+        waitedMs: Date.now() - gateStart,
+      };
+      if (!entityGate.complete) {
+        console.error(
+          `[boundary_create] entity gate: only ${entitiesVisible}/${expectedCount} visible after ${entityGate.waitedMs}ms — relationships will retry stragglers`,
+        );
+      }
+
+      // Step 3: Create relationships top-down (ordered by hierarchy level), with
+      // a bounded retry for any entity still not visible / parent not yet linked
+      // (cascade) despite the gate.
       const levelOrder = new Map(hierarchyLevels.map((l, i) => [l, i]));
       const sorted = [...boundaries].sort((a, b) => {
         const aOrder = levelOrder.get(a.type) ?? 999;
@@ -814,24 +864,35 @@ export function registerValidatorTools(registry: ToolRegistry): void {
         return aOrder - bOrder;
       });
 
-      for (const b of sorted) {
-        try {
-          await digitApi.boundaryRelationshipCreate(
-            tenantId,
-            b.code,
-            hierarchyType,
-            b.type,
-            b.parent || null
-          );
-          results.relationshipsCreated.push(b.code);
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          if (msg.includes('DUPLICATE') || msg.includes('already exists') || msg.includes('unique')) {
-            results.relationshipsSkipped.push(b.code);
-          } else {
-            results.errors.push({ code: b.code, step: 'relationship_create', error: msg });
+      const isMissingEntity = (m: string) =>
+        m.includes('DOES_NOT_EXIST') || m.includes('does not exist') || m.includes('not found');
+      const MAX_PASSES = 4;
+      let pending = sorted;
+      for (let pass = 0; pass < MAX_PASSES && pending.length > 0; pass++) {
+        if (pass > 0) await sleep(2000);
+        const stillPending: typeof pending = [];
+        for (const b of pending) {
+          try {
+            await digitApi.boundaryRelationshipCreate(
+              tenantId,
+              b.code,
+              hierarchyType,
+              b.type,
+              b.parent || null,
+            );
+            results.relationshipsCreated.push(b.code);
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            if (msg.includes('DUPLICATE') || msg.includes('already exists') || msg.includes('unique')) {
+              results.relationshipsSkipped.push(b.code);
+            } else if (isMissingEntity(msg) && pass < MAX_PASSES - 1) {
+              stillPending.push(b); // entity not visible yet or parent cascade — retry next pass
+            } else {
+              results.errors.push({ code: b.code, step: 'relationship_create', error: msg });
+            }
           }
         }
+        pending = stillPending;
       }
 
       return JSON.stringify({
@@ -841,6 +902,7 @@ export function registerValidatorTools(registry: ToolRegistry): void {
         summary: {
           entitiesCreated: results.entitiesCreated.length,
           entitiesSkipped: results.entitiesSkipped.length,
+          entityGate,
           relationshipsCreated: results.relationshipsCreated.length,
           relationshipsSkipped: results.relationshipsSkipped.length,
           errors: results.errors.length,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -41,11 +41,18 @@ export function validateMobileNumber(num: unknown, field = 'mobile_number'): str
   if (typeof num !== 'string' || !num) {
     throw new ValidationError(field, `${field} is required`);
   }
-  const cleaned = num.replace(/[\s\-()]/g, '');
-  if (!/^\d{10}$/.test(cleaned)) {
+  const cleaned = num.replace(/[\s\-()+]/g, '');
+  // Country-agnostic: the per-tenant common-masters.UserValidation 'mobile'
+  // rule (egov-user) is the source of truth for the exact pattern/length.
+  // Don't hardcode India's 10-digit here — that rejects Kenya (9, starts 1/7),
+  // Mozambique (9, starts 8), etc. before the request even reaches the backend.
+  // Just sanity-check it's digits of a plausible length; the backend enforces
+  // the tenant's real rule.
+  if (!/^\d{6,15}$/.test(cleaned)) {
     throw new ValidationError(
       field,
-      `${field} must be exactly 10 digits. Got "${num}" (${cleaned.length} digits after cleanup).`
+      `${field} must be 6-15 digits. Got "${num}" (${cleaned.length} digits after cleanup). ` +
+      `The tenant's common-masters.UserValidation 'mobile' rule enforces the exact pattern.`
     );
   }
   return cleaned;

--- a/src/utils/xlsx-loader.ts
+++ b/src/utils/xlsx-loader.ts
@@ -251,12 +251,11 @@ async function runBoundaryPhase(
   const entityFailures: string[] = [];
   const relFailures: string[] = [];
 
+  // ── Phase A: create ALL entities first (every level), batched ──
+  // egov-boundary-service /boundary/_create takes an array, so 100-at-a-time
+  // keeps round-trips low without blowing past payload limits.
   for (const level of fileLevels) {
     const levelRows = rowsByLevel.get(level) ?? [];
-
-    // Entities first (batched). egov-boundary-service /boundary/_create
-    // takes an array, so 100-at-a-time keeps round-trips low without
-    // blowing past payload limits.
     const BATCH = 100;
     for (let i = 0; i < levelRows.length; i += BATCH) {
       const batch = levelRows.slice(i, i + BATCH);
@@ -288,18 +287,61 @@ async function runBoundaryPhase(
         }
       }
     }
+  }
 
-    // Relationships one-at-a-time. The API only takes singletons, and the
-    // boundary-service occasionally returns "Boundary entity does not exist"
-    // or "Parent entity for current boundary relationship does not exist"
-    // even when the row is in the DB — Kafka/cache lag from the batched
-    // entity creates above. Re-queue race-style failures and retry with
-    // backoff before declaring real failure.
+  // ── Phase B: ENTITY GATE — wait until every entity is readable before any
+  // relationship is created. boundary-service entity _create is Kafka-backed:
+  // it returns 200 before the row is consistently readable, and relationship
+  // _create validates entity existence, so without this barrier a subset of
+  // relationships race ahead of their entity ("Boundary entity does not exist")
+  // and their children cascade. (A per-level ~5s retry can't keep up at
+  // thousands of rows.) Poll boundary search until all expected codes appear.
+  // /boundary/_search caps results (~300), so we can't count all entities in
+  // one call — verify the exact codes via the `codes` filter in chunks.
+  const expectedCodeList = rows.map((r) => r.code);
+  const expectedCount = new Set(expectedCodeList).size;
+  const GATE_TIMEOUT_MS = 180000;
+  const GATE_INTERVAL_MS = 2000;
+  const CODES_CHUNK = 200; // keep each query under the result cap
+  const countVisibleEntities = async (): Promise<number> => {
+    const seen = new Set<string>();
+    for (let i = 0; i < expectedCodeList.length; i += CODES_CHUNK) {
+      const chunk = expectedCodeList.slice(i, i + CODES_CHUNK);
+      // explicit limit: /boundary/_search defaults to 50 results even when
+      // codes are supplied, so without this the gate undercounts and stalls.
+      const res = await digitApi
+        .boundarySearch(tenantId, undefined, { codes: chunk, limit: chunk.length })
+        .catch(() => [] as Record<string, unknown>[]);
+      const present = new Set((res as Record<string, unknown>[]).map((e) => e.code as string));
+      for (const c of chunk) if (present.has(c)) seen.add(c);
+    }
+    return seen.size;
+  };
+  const gateStart = Date.now();
+  let entitiesVisible = 0;
+  while (Date.now() - gateStart < GATE_TIMEOUT_MS) {
+    entitiesVisible = await countVisibleEntities();
+    if (entitiesVisible >= expectedCount) break;
+    await new Promise((resolve) => setTimeout(resolve, GATE_INTERVAL_MS));
+  }
+  const entityGate = {
+    expected: expectedCount,
+    visible: entitiesVisible,
+    complete: entitiesVisible >= expectedCount,
+    waitedMs: Date.now() - gateStart,
+  };
+
+  // ── Phase C: create relationships top-down (levels root→leaf). A child
+  // relationship needs its parent's relationship to exist, so level order
+  // matters; the gate above guarantees the entities are visible. Keep a
+  // bounded retry as a safety net for any residual lag / parent stragglers.
+  for (const level of fileLevels) {
+    const levelRows = rowsByLevel.get(level) ?? [];
     const pending: BoundaryRow[] = [...levelRows];
     const maxPasses = 5;
     for (let pass = 0; pass < maxPasses && pending.length > 0; pass++) {
       if (pass > 0) {
-        const backoffMs = 500 * pass;
+        const backoffMs = 1000 * pass;
         await new Promise((resolve) => setTimeout(resolve, backoffMs));
       }
       const stillPending: BoundaryRow[] = [];
@@ -313,7 +355,7 @@ async function runBoundaryPhase(
           const msg = err instanceof Error ? err.message : String(err);
           if (/already exists|duplicate/i.test(msg)) {
             relStats.exists++;
-          } else if (/entity does not exist|parent.*does not exist/i.test(msg) && pass < maxPasses - 1) {
+          } else if (/does not exist|DOES_NOT_EXIST/i.test(msg) && pass < maxPasses - 1) {
             stillPending.push(b);
           } else {
             relStats.failed++;
@@ -345,7 +387,7 @@ async function runBoundaryPhase(
     hierarchyType,
     hierarchyAction,
     levels: fileLevels,
-    counts: { entities: entityStats, relationships: relStats, total_rows: rows.length },
+    counts: { entities: entityStats, relationships: relStats, total_rows: rows.length, entity_gate: entityGate },
     entity_failures: entityFailures,
     relationship_failures: relFailures,
     context,

--- a/test-e2e-new-tenant.ts
+++ b/test-e2e-new-tenant.ts
@@ -204,6 +204,10 @@ async function main() {
     const r = await call('tenant_bootstrap', {
       target_tenant: state.bootstrapRoot,
       source_tenant: 'pg',
+      // Exercise the config-driven UserValidation synth with a non-default
+      // (9-digit, MZ-style) mobile rule so steps 5a/5b can assert it landed.
+      mobile_regex: '^8[0-9]{8}$',
+      mobile_length: 9,
     });
     const summary = r.summary as Record<string, number> | undefined;
     const schemasCopied = summary?.schemas_copied ?? 0;
@@ -250,6 +254,44 @@ async function main() {
     const validation = r.validation as Record<string, unknown>;
     console.log(`        ${validation.summary}`);
     return ['validate_designations'];
+  });
+
+  // 5a. UserValidation 'mobile' rule synthesized with the right shape.
+  // Source tenants ship no UserValidation; tenant_bootstrap must synthesize
+  // the egov-user ValidationData shape { fieldType:'mobile', isActive,
+  // rules:{pattern,minLength,maxLength} } at the EXACT tenant, or citizen
+  // register falls back to the hardcoded 10-digit regex.
+  await testWithDeps('5a UserValidation mobile rule synthesized', ['2 bootstrap new root tenant'], async () => {
+    await wait(2000, 'MDMS data propagation');
+    const r = await call('mdms_search', {
+      tenant_id: state.bootstrapRoot,
+      schema_code: 'common-masters.UserValidation',
+    });
+    assert(r.success === true, `mdms_search UserValidation failed: ${r.error}`);
+    // mdms_search returns { records: [{ uniqueIdentifier, data:{...}, isActive }] }
+    const recs = (r.records as Array<{ data?: Record<string, unknown> }>) || [];
+    const mobile = recs.map((x) => x.data || {}).find((d) => d.fieldType === 'mobile');
+    assert(!!mobile, `No UserValidation record with fieldType='mobile' (got ${recs.length} records)`);
+    const rules = (mobile as { rules?: Record<string, unknown> }).rules || {};
+    assert(rules.pattern === '^8[0-9]{8}$', `mobile pattern wrong: ${JSON.stringify(rules.pattern)}`);
+    assert(Number(rules.minLength) === 9 && Number(rules.maxLength) === 9, `mobile length wrong: ${rules.minLength}/${rules.maxLength}`);
+    console.log(`        UserValidation/mobile: pattern=${rules.pattern} len=${rules.minLength}-${rules.maxLength}`);
+    return ['mdms_search'];
+  });
+
+  // 5b. ACCESSCONTROL-ACTIONS.actions bridged from -TEST.
+  // egov-accesscontrol reads the non-TEST schema; pg ships only -TEST.
+  // The bridge must clone rows (preserving data.id) or the employee UI is blank.
+  await testWithDeps('5b ACCESSCONTROL-ACTIONS bridged', ['2 bootstrap new root tenant'], async () => {
+    const r = await call('mdms_search', {
+      tenant_id: state.bootstrapRoot,
+      schema_code: 'ACCESSCONTROL-ACTIONS.actions',
+    });
+    assert(r.success === true, `mdms_search ACCESSCONTROL-ACTIONS.actions failed: ${r.error}`);
+    const count = (r.count as number) ?? ((r.data as unknown[]) || []).length;
+    assert(count > 0, `ACCESSCONTROL-ACTIONS.actions empty — bridge from -TEST didn't run (got ${count})`);
+    console.log(`        ACCESSCONTROL-ACTIONS.actions: ${count} rows bridged`);
+    return ['mdms_search'];
   });
 
   // ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Two empirically-verified gaps that block a fresh non-pg tenant (validated on Maputo `mz`/`mz.maputo`, Mac/OrbStack, db_fast_path).

### 1. Synthesize `common-masters.UserValidation` mobile rule
Source tenants (pg/statea) ship **no** UserValidation. Without a `mobile` rule, egov-user (`>=1.2.8`, `MobileNumberValidator`) falls back to a hardcoded `(^$|[0-9]{10})` regex and rejects 9-digit MZ/Kenya mobiles → citizen register fails `INVALID_MOBILE_LENGTH`.

**The shape matters** — this egov-user build uses a `ValidationData` model (decompiled to confirm):
```json
{ "fieldType": "mobile", "isActive": true,
  "rules": { "pattern": "^8[0-9]{8}$", "minLength": 9, "maxLength": 9, "errorMessage": "..." } }
```
One record per field, filtered by `fieldType=='mobile' && isActive`. (The legacy flat `{userName,mobileNumber,...}` regex map is NOT read by this build.)

- New inputs: `mobile_regex` (default `^[6-9][0-9]{9}$`), `mobile_length` (default 10).
- uid derived via `x-unique:['fieldType']` → `mobile` (mdms-v2 requires x-unique on schema-create; pointing it at fieldType gives a stable correct uid).
- Created at the **exact** target tenant — mdms-v2 search is hierarchical (a city query returns the root's rows too), but egov-user resolves UserValidation by exact tenant, so root + city each need their own `mobile` row.

### 2. Bridge `ACCESSCONTROL-ACTIONS.actions` from `-TEST`
egov-accesscontrol reads `ACCESSCONTROL-ACTIONS.actions`, but pg/statea ship only `ACCESSCONTROL-ACTIONS-TEST.actions-test`. Clone the schema def under the non-TEST code and copy every row **preserving `data.id`** so `roleactions.actionid` cross-refs resolve (else the employee UI renders blank).

## Validation (Maputo mz.maputo)
```
9-digit MZ mobile register → passes mobile validation (UserNameNotValid = UI-handled OTP artifact, same as pg)
7-digit bad mobile → correctly rejected (rule active + discriminating)
ADMIN@mz.maputo employee login → 200
253 actions bridged
```
All via the MCP API — no SQL bypass.

## Notes
- Idempotent: skip-if-exists at exact tenant; duplicate-tolerant.
- Pairs with CCRS PR #52 (the ansible `mcp-bootstrap` task now threads `mobile_regex`/`mobile_length` from `core_mobile_configs`).
- Remaining gap (separate, cosmetic): StateInfo `name` still 'Demo' (code IS rewritten) — branding-field rewrite TBD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant bootstrap supports configurable mobile validation (regex + length) with sensible defaults and auto-generates compliant mobile values for seeded users.
  * Access-control actions are automatically synchronized from test to target schemas during bootstrap.

* **Bug Fixes / Improvements**
  * Mobile validation made country-agnostic (broader cleanup, accepts 6–15 digits).
  * Tool input description updated to reflect tenant-level mobile rules.

* **Tests**
  * New end-to-end checks validate synthesized mobile rules and actions bridging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/DIGIT-MCP/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->